### PR TITLE
Feature/support any number versions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,27 +3,54 @@ var pify = require('pify');
 var objectAssign = require('object-assign');
 var Promise = require('pinkie-promise');
 
+function getAllVersions(lambda, opts, previousVersions, maxItems, marker) {
+	var params = { FunctionName: opts.FunctionName };
+
+	if (marker) {
+		params.Marker = marker;
+	}
+
+	if (maxItems) {
+		// By default, AWS returns 50 items
+		params.MaxItems = maxItems
+	}
+
+	return pify(lambda.listVersionsByFunction.bind(lambda), Promise)(params)
+		.then(function (data) {
+			if (!data.Versions || data.Versions.length === 0) {
+				if (previousVersions.length === 0) {
+					throw new Error('No versions found.');
+				}
+
+				return previousVersions;
+			}
+
+			var newVersions = previousVersions.concat(data.Versions);
+			if (data.NextMarker) {
+				return getAllVersions(lambda, opts, newVersions, maxItems, data.NextMarker);
+			}
+
+			return newVersions;
+		});
+}
+
 function findLatestVersion(lambda, opts) {
 	if (opts.FunctionVersion) {
 		// Return the function version if it was provided
 		return Promise.resolve(opts.FunctionVersion);
 	}
 
-	return pify(lambda.listVersionsByFunction.bind(lambda), Promise)({FunctionName: opts.FunctionName})
-		.then(function (data) {
-			if (!data.Versions || data.Versions.length === 0) {
-				throw new Error('No versions found.');
-			}
-
+	return getAllVersions(lambda, opts, [])
+		.then(function (versions) {
 			// Sort all the versions
-			data.Versions.sort(function (a, b) {
+			versions.sort(function (a, b) {
 				var aVersion = a.Version === '$LATEST' ? 0 : parseInt(a.Version, 10);
 				var bVersion = b.Version === '$LATEST' ? 0 : parseInt(b.Version, 10);
 
 				return bVersion - aVersion;
 			});
 
-			return data.Versions[0].Version;
+			return versions[0].Version;
 		});
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,12 +9,12 @@ test.before(() => {
 	sinon.stub(utils, 'updateOrCreate');
 });
 
-test('throw error if no lambda function name is provided', t => {
-	t.throws(m(), 'Provide a AWS Lambda function name.');
+test('throw error if no lambda function name is provided', async t => {
+	await t.throwsAsync(m(), 'Provide a AWS Lambda function name.');
 });
 
-test('throw error if no alias name is provided', t => {
-	t.throws(m('foo'), 'Provide an alias name.');
+test('throw error if no alias name is provided', async t => {
+	await t.throwsAsync(m('foo'), 'Provide an alias name.');
 });
 
 test('specify the aws profile', async t => {
@@ -39,7 +39,7 @@ test.serial('provide region property', async t => {
 
 test.serial('update or create the alias', async t => {
 	await m('foo', 'v1');
-	t.same(utils.updateOrCreate.lastCall.args[1], {
+	t.deepEqual(utils.updateOrCreate.lastCall.args[1], {
 		FunctionName: 'foo',
 		Name: 'v1'
 	});
@@ -47,7 +47,7 @@ test.serial('update or create the alias', async t => {
 
 test.serial('update or create the alias on a specific version', async t => {
 	await m('foo', 'v1', {version: '1'});
-	t.same(utils.updateOrCreate.lastCall.args[1], {
+	t.deepEqual(utils.updateOrCreate.lastCall.args[1], {
 		FunctionName: 'foo',
 		FunctionVersion: '1',
 		Name: 'v1'


### PR DESCRIPTION
Thank you for this package Sam. We have been using it during the last months and everything was right.

In the last days we have discovered a weak in the package. If the versions associated with a lambda are more than 50 (the default number of versions returned by `AWS.Lambda.listVersionsByFunction`), and the lib has to calculate the last version number, this calculation can be wrong, because it doesn't get every version (just the first 50 ones).

I've modified the lib, making recursive calls when needed, to get every lambda version from AWS. Moreover, I've updated the tests to make them compatible with the installed version of ava, and I've added a test for the new feature.

I hope this PR could me merge in your library :-)